### PR TITLE
Changed spice serving count from null to 1.0

### DIFF
--- a/DailyDozen/app/src/main/java/org/nutritionfacts/dailydozen/food/FoodHelper.java
+++ b/DailyDozen/app/src/main/java/org/nutritionfacts/dailydozen/food/FoodHelper.java
@@ -104,7 +104,7 @@ public class FoodHelper {
             foodType.iconResourceId = R.drawable.ic_spices;
             foodType.overviewImageResourceId = R.drawable.spices;
             foodType.name = resources.getString(R.string.food_type_spices_name);
-            foodType.recommendedServingCount = -1.0;
+            foodType.recommendedServingCount = 1.0;
             foodType.exampleTitles.add(resources.getString(R.string.my_favorites));
             foodType.exampleBodies.add(resources.getString(R.string.food_type_spices_example));
 


### PR DESCRIPTION
While each row is built, the checkbox is loaded based on the count of serving it can go up to. With a null serving count (-1), no checkbox will be loaded.