### PR TITLE
Adding AA_MODELS to relieve instant run issue

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,10 @@
         <meta-data
             android:name="AA_DB_VERSION"
             android:value="3" />
-
+        <meta-data
+            android:name="AA_MODELS"
+            android:value="org.nutritionfacts.dailydozen.model.Day, org.nutritionfacts.dailydozen.model.Food, org.nutritionfacts.dailydozen.model.Servings" />
+        
         <activity
             android:name=".activity.MainActivity"
             android:launchMode="singleTask"


### PR DESCRIPTION
- activeandroid can say that a table does not exist when debugging with Instant Run in Android Studio
- This stopped when the model was added to the AndroidManifest
