### PR TITLE
Remove rice

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -318,7 +318,6 @@
 
     <string-array name="food_info_types_whole_grains">
         <item>Ечемик</item>
-        <item>Кафяв ориз</item>
         <item>Елда</item>
         <item>Просо</item>
         <item>Овесени ядки</item>
@@ -327,7 +326,6 @@
         <item>Ръж</item>
         <item>Теф</item>
         <item>Пълнозърнеста паста</item>
-        <item>Див ориз</item>
     </string-array>
 
     <string-array name="food_info_types_beverages">

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -310,7 +310,6 @@
     
     <string-array name="food_info_types_whole_grains">
         <item>Gerste</item>
-        <item>Brauner Reis</item>
         <item>Buchweizen</item>
         <item>Hirse</item>
         <item>Hafer</item>
@@ -319,7 +318,6 @@
         <item>Roggen</item>
         <item>Teff</item>
         <item>Vollkornnudeln</item>
-        <item>Wildreis</item>
     </string-array>
     
     <string-array name="food_info_types_beverages">

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -318,7 +318,6 @@
 
     <string-array name="food_info_types_whole_grains">
         <item>Κριθάρι</item>
-        <item>Καστανό ρύζι</item>
         <item>Φαγόπυρο</item>
         <item>Κεχρί</item>
         <item>Βρώμη</item>
@@ -327,7 +326,6 @@
         <item>Σίκαλη</item>
         <item>Τεφ</item>
         <item>Ζυμαρικά ολικής αλέσεως</item>
-        <item>Αγριο ρύζι</item>
     </string-array>
 
     <string-array name="food_info_types_beverages">

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -318,7 +318,6 @@
 
     <string-array name="food_info_types_whole_grains">
         <item>Cebada</item>
-        <item>Arroz integral</item>
         <item>Alforfón</item>
         <item>Mijo</item>
         <item>Avena</item>
@@ -327,7 +326,6 @@
         <item>Centeno</item>
         <item>Teff</item>
         <item>Pasta integral</item>
-        <item>Arroz salvaje</item>
     </string-array>
 
     <string-array name="food_info_types_beverages">

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -319,7 +319,6 @@
 
     <string-array name="food_info_types_whole_grains">
         <item>Orge</item>
-        <item>Riz brun</item>
         <item>Sarrasin</item>
         <item>Millet</item>
         <item>Avoine</item>
@@ -328,7 +327,6 @@
         <item>Seigle</item>
         <item>Teff</item>
         <item>Pâtes de blé entier</item>
-        <item>Riz sauvage</item>
     </string-array>
 
     <string-array name="food_info_types_beverages">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -405,7 +405,6 @@
 
     <string-array name="food_info_types_whole_grains">
         <item>Barley</item>
-        <item>Brown rice</item>
         <item>Buckwheat</item>
         <item>Millet</item>
         <item>Oats</item>
@@ -414,7 +413,6 @@
         <item>Rye</item>
         <item>Teff</item>
         <item>Whole-wheat pasta</item>
-        <item>Wild rice</item>
     </string-array>
 
     <string-array name="food_info_types_beverages">
@@ -862,7 +860,6 @@
 
     <string-array name="food_videos_whole_grains" translatable="false">
         <item>barley</item>
-        <item>rice</item>
         <item>buckwheat</item>
         <item>millet</item>
         <item>oats</item>
@@ -871,7 +868,6 @@
         <item>rye</item>
         <item>teff</item>
         <item>pasta</item>
-        <item>rice</item>
     </string-array>
 
     <string-array name="food_videos_beverages" translatable="false">


### PR DESCRIPTION
Remove all types of rice in all languages due to a [high level of arsenic](https://nutritionfacts.org/?fwp_search=arsenic%20rice&fwp_content_type=video).

Fixes #60.

(Also please create a `develop` branch as per [CONTRIBUTING.md](https://github.com/nutritionfactsorg/daily-dozen-android/blob/master/CONTRIBUTING.md#submit).)