### PR TITLE
Add kale cauliflower & cabbage types, kohlrabi, romanesco

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -303,7 +303,7 @@
         <item>Broccoli</item>
         <item>Brussels sprouts</item>
         <item>Cabbage</item>
-        <item>Cauliflower</item>
+        <item>Cauliflower (white, green, orange and purple)</item>
         <item>Collard greens</item>
         <item>Horseradish</item>
         <item>Kale (curly, lacinato and red Russian)</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -303,6 +303,7 @@
         <item>Broccoli (including Romanesco)</item>
         <item>Brussels sprouts</item>
         <item>Cabbage (green, red and savoy)</item>
+        <item>Kohlrabi (green and purple)</item>
         <item>Cauliflower (white, green, orange and purple)</item>
         <item>Collard greens</item>
         <item>Horseradish</item>
@@ -765,6 +766,7 @@
         <item>broccoli</item>
         <item>brussels-sprouts</item>
         <item>cabbage</item>
+        <item>kohlrabi</item>
         <item>cauliflower</item>
         <item>collard-greens</item>
         <item></item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -306,7 +306,7 @@
         <item>Cauliflower</item>
         <item>Collard greens</item>
         <item>Horseradish</item>
-        <item>Kale (black, green, and red)</item>
+        <item>Kale (curly, lacinato and red Russian)</item>
         <item>Mustard greens</item>
         <item>Radishes</item>
         <item>Turnip greens</item>
@@ -317,7 +317,7 @@
         <item>Arugula</item>
         <item>Beet greens</item>
         <item>Collard greens</item>
-        <item>Kale (black, green, and red)</item>
+        <item>Kale (curly, lacinato and red Russian)</item>
         <item>Mesclun mix (assorted young salad greens)</item>
         <item>Mustard greens</item>
         <item>Sorrel</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -302,7 +302,7 @@
         <item>Bok choy</item>
         <item>Broccoli (including Romanesco)</item>
         <item>Brussels sprouts</item>
-        <item>Cabbage</item>
+        <item>Cabbage (green, red and savoy)</item>
         <item>Cauliflower (white, green, orange and purple)</item>
         <item>Collard greens</item>
         <item>Horseradish</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -300,7 +300,7 @@
     <string-array name="food_info_types_cruciferous_vegetables">
         <item>Arugula</item>
         <item>Bok choy</item>
-        <item>Broccoli</item>
+        <item>Broccoli (including Romanesco)</item>
         <item>Brussels sprouts</item>
         <item>Cabbage</item>
         <item>Cauliflower (white, green, orange and purple)</item>


### PR DESCRIPTION
I suggest to add 3 main types of kale: Curly-leaf kale (can be green or purple-red), Lacinato kale (so called "black kale") and 'red Russian' kale.

I also add romanesco (broccoli), kohlrabi, colourful cauliflower and 3 cabbage types.