### PR TITLE
Fix error "Could not find com.android.tools.build:gradle:3.0.1"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
@@ -15,6 +16,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 


### PR DESCRIPTION
As per the [Configure Your Build documentation](https://developer.android.com/studio/build/index.html#top-level) Google's repository is needed when using Android plugin for Gradle version 3.0.1 as a classpath dependency.

The building from the command line also fails:
```
./gradlew assembleDebug

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'daily-dozen-android'.
> Could not resolve all files for configuration ':classpath'.
   > Could not find com.android.tools.build:gradle:3.0.1.
     Searched in the following locations:
         https://jcenter.bintray.com/com/android/tools/build/gradle/3.0.1/gradle-3.0.1.pom
         https://jcenter.bintray.com/com/android/tools/build/gradle/3.0.1/gradle-3.0.1.jar
     Required by:
         project :

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

* Get more help at https://help.gradle.org

```

Not sure why it works without it from Android Studio.

Encountered this error while running `build-fdroid.sh` to test if the F-Droid build works locally: https://forum.f-droid.org/t/build-failing-with-could-not-find-gradle-error/1612