### PR TITLE
Remove supplement divider

### DIFF
--- a/app/src/main/java/org/nutritionfacts/dailydozen/fragment/DailyDozenFragment.java
+++ b/app/src/main/java/org/nutritionfacts/dailydozen/fragment/DailyDozenFragment.java
@@ -95,17 +95,11 @@ public class DailyDozenFragment extends Fragment {
                 dateHeader.setServings(DDServings.getTotalServingsOnDate(day));
 
                 final Context context = getContext();
-                boolean addedSupplementDivider = false;
 
                 for (Food food : Food.getAllFoods()) {
                     final FoodServings foodServings = new FoodServings(context);
                     final boolean success = foodServings.setDateAndFood(day, food);
                     if (success) {
-                        if (Common.isSupplement(food) && !addedSupplementDivider) {
-                            vgFoodServings.addView(new SupplementDivider(context));
-                            addedSupplementDivider = true;
-                        }
-
                         vgFoodServings.addView(foodServings);
                         Bus.register(foodServings);
                     }


### PR DESCRIPTION
Removes the duplicate divider on the daily dozen fragment above the supplement item