### PR TITLE
Force Dark Mode Tweaks

### DIFF
--- a/app/src/main/java/org/nutritionfacts/dailydozen/Common.java
+++ b/app/src/main/java/org/nutritionfacts/dailydozen/Common.java
@@ -5,6 +5,7 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.net.Uri;
 import android.view.View;
 import android.widget.ImageView;
@@ -204,5 +205,9 @@ public class Common {
         TweakServings.truncate(TweakServings.class);
         Weights.truncate(Weights.class);
         Day.truncate(Day.class);
+    }
+
+    public static boolean isAppInDarkMode(final Context context) {
+        return (context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
     }
 }

--- a/app/src/main/java/org/nutritionfacts/dailydozen/activity/FoodHistoryActivity.java
+++ b/app/src/main/java/org/nutritionfacts/dailydozen/activity/FoodHistoryActivity.java
@@ -7,6 +7,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
+import androidx.cardview.widget.CardView;
 import androidx.core.content.ContextCompat;
 
 import com.prolificinteractive.materialcalendarview.CalendarDay;
@@ -36,6 +37,8 @@ import butterknife.ButterKnife;
 import hirondelle.date4j.DateTime;
 
 public class FoodHistoryActivity extends InfoActivity {
+    @BindView(R.id.history_card_container)
+    protected CardView cardView;
     @BindView(R.id.calendar_legend)
     protected ViewGroup vgLegend;
     @BindView(R.id.calendarView)
@@ -68,6 +71,11 @@ public class FoodHistoryActivity extends InfoActivity {
             initCalendar(food.getId(), food.getRecommendedAmount());
 
             displayEntriesForVisibleMonths(Calendar.getInstance(), food.getId());
+
+            if (Common.isAppInDarkMode(this)) {
+                cardView.setForceDarkAllowed(false);
+                cardView.setCardBackgroundColor(ContextCompat.getColor(this, R.color.gray));
+            }
         }
     }
 

--- a/app/src/main/java/org/nutritionfacts/dailydozen/activity/TweakHistoryActivity.java
+++ b/app/src/main/java/org/nutritionfacts/dailydozen/activity/TweakHistoryActivity.java
@@ -7,6 +7,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
+import androidx.cardview.widget.CardView;
 import androidx.core.content.ContextCompat;
 
 import com.prolificinteractive.materialcalendarview.CalendarDay;
@@ -36,6 +37,8 @@ import butterknife.ButterKnife;
 import hirondelle.date4j.DateTime;
 
 public class TweakHistoryActivity extends TweakLoadingActivity {
+    @BindView(R.id.history_card_container)
+    protected CardView cardView;
     @BindView(R.id.calendar_legend)
     protected ViewGroup vgLegend;
     @BindView(R.id.calendarView)
@@ -68,6 +71,11 @@ public class TweakHistoryActivity extends TweakLoadingActivity {
             initCalendar(tweak.getId(), tweak.getRecommendedAmount());
 
             displayEntriesForVisibleMonths(Calendar.getInstance(), tweak.getId());
+
+            if (Common.isAppInDarkMode(this)) {
+                cardView.setForceDarkAllowed(false);
+                cardView.setCardBackgroundColor(ContextCompat.getColor(this, R.color.gray));
+            }
         }
     }
 

--- a/app/src/main/java/org/nutritionfacts/dailydozen/task/LoadServingsHistoryTask.java
+++ b/app/src/main/java/org/nutritionfacts/dailydozen/task/LoadServingsHistoryTask.java
@@ -14,6 +14,7 @@ import com.github.mikephil.charting.data.LineDataSet;
 import com.github.mikephil.charting.formatter.ValueFormatter;
 import com.github.mikephil.charting.utils.ViewPortHandler;
 
+import org.nutritionfacts.dailydozen.Common;
 import org.nutritionfacts.dailydozen.R;
 import org.nutritionfacts.dailydozen.controller.Bus;
 import org.nutritionfacts.dailydozen.event.LoadHistoryCompleteEvent;
@@ -241,7 +242,8 @@ public class LoadServingsHistoryTask
     private LineData getLineData(List<String> xVals, List<Entry> lineEntries) {
         final LineDataSet dataSet = new LineDataSet(lineEntries, getContext().getString(R.string.moving_average));
 
-        final int color = ContextCompat.getColor(getContext(), R.color.brown);
+        final int color = ContextCompat.getColor(getContext(),
+                Common.isAppInDarkMode(getContext()) ? R.color.gold : R.color.brown);
 
         dataSet.setColor(color);
         dataSet.setLineWidth(2.5f);

--- a/app/src/main/java/org/nutritionfacts/dailydozen/task/LoadTweakServingsHistoryTask.java
+++ b/app/src/main/java/org/nutritionfacts/dailydozen/task/LoadTweakServingsHistoryTask.java
@@ -14,6 +14,7 @@ import com.github.mikephil.charting.data.LineDataSet;
 import com.github.mikephil.charting.formatter.ValueFormatter;
 import com.github.mikephil.charting.utils.ViewPortHandler;
 
+import org.nutritionfacts.dailydozen.Common;
 import org.nutritionfacts.dailydozen.R;
 import org.nutritionfacts.dailydozen.controller.Bus;
 import org.nutritionfacts.dailydozen.event.LoadHistoryCompleteEvent;
@@ -241,7 +242,8 @@ public class LoadTweakServingsHistoryTask
     private LineData getLineData(List<String> xVals, List<Entry> lineEntries) {
         final LineDataSet dataSet = new LineDataSet(lineEntries, getContext().getString(R.string.moving_average));
 
-        final int color = ContextCompat.getColor(getContext(), R.color.brown);
+        final int color = ContextCompat.getColor(getContext(),
+                Common.isAppInDarkMode(getContext()) ? R.color.gold : R.color.brown);
 
         dataSet.setColor(color);
         dataSet.setLineWidth(2.5f);

--- a/app/src/main/java/org/nutritionfacts/dailydozen/task/LoadWeightsHistoryTask.java
+++ b/app/src/main/java/org/nutritionfacts/dailydozen/task/LoadWeightsHistoryTask.java
@@ -14,6 +14,7 @@ import com.github.mikephil.charting.data.LineDataSet;
 import com.github.mikephil.charting.formatter.ValueFormatter;
 import com.github.mikephil.charting.utils.ViewPortHandler;
 
+import org.nutritionfacts.dailydozen.Common;
 import org.nutritionfacts.dailydozen.R;
 import org.nutritionfacts.dailydozen.controller.Bus;
 import org.nutritionfacts.dailydozen.event.LoadHistoryCompleteEvent;
@@ -263,7 +264,8 @@ public class LoadWeightsHistoryTask
     private LineData getLineData(List<String> xVals, List<Entry> lineEntries) {
         final LineDataSet dataSet = new LineDataSet(lineEntries, getContext().getString(R.string.moving_average));
 
-        final int color = ContextCompat.getColor(getContext(), R.color.brown);
+        final int color = ContextCompat.getColor(getContext(),
+                Common.isAppInDarkMode(getContext()) ? R.color.gold : R.color.brown);
 
         dataSet.setColor(color);
         dataSet.setLineWidth(2.5f);

--- a/app/src/main/java/org/nutritionfacts/dailydozen/widget/StreakWidget.java
+++ b/app/src/main/java/org/nutritionfacts/dailydozen/widget/StreakWidget.java
@@ -1,6 +1,7 @@
 package org.nutritionfacts.dailydozen.widget;
 
 import android.content.Context;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.view.View;
 
@@ -31,7 +32,10 @@ public class StreakWidget extends IconTextView {
 
     public void setStreak(int streak) {
         if (streak > ONE_DAY) {
-            setForceDarkAllowed(false);
+            if (Build.VERSION.SDK_INT >= 29) {
+                setForceDarkAllowed(false);
+            }
+
             setVisibility(View.VISIBLE);
 
             setText(getContext().getString(R.string.format_num_days, streak));

--- a/app/src/main/java/org/nutritionfacts/dailydozen/widget/StreakWidget.java
+++ b/app/src/main/java/org/nutritionfacts/dailydozen/widget/StreakWidget.java
@@ -31,6 +31,7 @@ public class StreakWidget extends IconTextView {
 
     public void setStreak(int streak) {
         if (streak > ONE_DAY) {
+            setForceDarkAllowed(false);
             setVisibility(View.VISIBLE);
 
             setText(getContext().getString(R.string.format_num_days, streak));

--- a/app/src/main/res/layout/activity_history.xml
+++ b/app/src/main/res/layout/activity_history.xml
@@ -10,6 +10,7 @@
         android:orientation="vertical">
 
         <androidx.cardview.widget.CardView
+            android:id="@+id/history_card_container"
             app:cardElevation="6dp"
             android:layout_margin="10dp"
             android:layout_width="match_parent"


### PR DESCRIPTION
This PR fixes the following minor issues with using the [Force Dark](https://developer.android.com/guide/topics/ui/look-and-feel/darktheme#force_dark) mode added in API level 29:

1. Force Dark mode is disabled on the StreakWidget as its normal colors look good in dark mode.
1. Force Dark mode is disabled in the calendar history views and the background is set to gray so as not to blind at night.
1. The color of the moving average line is changed to gold in dark mode to improve legibility.