### PR TITLE
czech update, dropped ".csv", contributors update

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -24,7 +24,7 @@
     <string name="moving_average">плъзгаща се средна</string>
     <string name="about">Относно</string>
     <string name="about_this_app">Информация за приложението</string>
-    <string name="about_translators">Специални благодарности на нашите преводачи доброволци: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
+    <string name="about_translators">Специални благодарности на нашите преводачи доброволци: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Ángela Graña (es), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
     <string name="latest_videos">Най-новите видео клипове</string>
     <string name="donate">Направете дарение</string>
     <string name="subscribe">Абонирай се</string>
@@ -54,7 +54,7 @@
     <string name="dialog_streaks_title">Нова функция: Линии!</string>
     <string name="dialog_streaks_message">Вашата база данни ще бъде обновена, за да поддържа новата функция „линии“.</string>
     <string name="dialog_no_email_apps_title">Няма намерени имейл приложения</string>
-    <string name="dialog_no_email_apps_message">Архивирането на данни изисква да имате инсталирано приложение за имейл, за да можете да изпратите csv файл по пощата. Моля инсталирайте имейл клиент и опитайте отново.</string>
+    <string name="dialog_no_email_apps_message">Архивирането на данни изисква да имате инсталирано приложение за имейл, за да можете да изпратите файл по пощата. Моля инсталирайте имейл клиент и опитайте отново.</string>
     <string name="debug_generate_random_data">Генериране на случайни данни</string>
     <string name="debug_generate_full_data">Генериране на пълна информация</string>
     <string name="debug_generate_data_message">Всички съществуващи данни ще бъдат заменени. Желаете ли да продължите?</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -24,7 +24,7 @@
     <string name="moving_average">Mesura mòbil</string>
     <string name="about">Informació</string>
     <string name="about_this_app">Sobre aquesta app</string>
-    <string name="about_translators">Special thanks to our volunteer translators: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
+    <string name="about_translators">Agraïment especial als nostres traductors voluntaris: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Ángela Graña (es), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
     <string name="latest_videos">Últims vídeos</string>
     <string name="donate">Donacions</string>
     <string name="subscribe">Subscriu-te</string>
@@ -54,7 +54,7 @@
     <string name="dialog_streaks_title">Nova eina: Gomets!</string>
     <string name="dialog_streaks_message">La teva base de dades s\'actualitzarà per afegir la nova eina del gomet.</string>
     <string name="dialog_no_email_apps_title">No s\'ha trobat cap aplicació de correu electrònic</string>
-    <string name="dialog_no_email_apps_message">Per fer una còpia de seguretat de les teves dades, has de tenir instal·lada una aplicació de correu electrònic perquè et puguis enviar l\'arxiu .csv amb la còpia a tu mateix. Sisuplau, instal·la una aplicació de correu electrònic i torna-ho a intentar.</string>
+    <string name="dialog_no_email_apps_message">Per fer una còpia de seguretat de les teves dades, has de tenir instal·lada una aplicació de correu electrònic perquè et puguis enviar l\'arxiu amb la còpia a tu mateix. Sisuplau, instal·la una aplicació de correu electrònic i torna-ho a intentar.</string>
     <string name="debug_generate_random_data">Genera dades aleatòries</string>
     <string name="debug_generate_full_data">Genera totes les dades</string>
     <string name="debug_generate_data_message">Es reemplaçaran totes les dades. Vols continuar?</string>
@@ -467,15 +467,15 @@
     </string-array>
     <string-array name="food_info_serving_sizes_cruciferous_vegetables_imperial">
         <item>½ tassa tallat</item>
-        <item>½ cup Brussels sprouts</item>
-        <item>¼ cup Broccoli sprouts</item>
-        <item>1 tablespoon horseradish</item>
+        <item>½ tassa de cols de Brussel·les</item>
+        <item>¼ tassa brots de bròquil</item>
+        <item>1 cullerada de rave picant</item>
     </string-array>
     <string-array name="food_info_serving_sizes_cruciferous_vegetables_metric">
         <item>30-80 g tallat</item>
-        <item>78 g Brussels sprouts</item>
-        <item>14 g Broccoli sprouts</item>
-        <item>1 tablespoon horseradish</item>
+        <item>78 g de cols de Brussel·les</item>
+        <item>14 g brots de bròquil</item>
+        <item>1 cullerada de rave picant</item>
     </string-array>
     <string-array name="food_info_serving_sizes_greens_imperial">
         <item>1 tassa crua</item>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -24,7 +24,7 @@
     <string name="moving_average">Pohyblivý průměr</string>
     <string name="about">Menu</string>
     <string name="about_this_app">O této aplikaci</string>
-    <string name="about_translators">Zvláštní poděkování patří našim dobrovolným překladatelům: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Doron Barak (on), Ruth Levy (on), Joanna Klopotek (pl), Tania Bassi ( pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
+    <string name="about_translators">Zvláštní poděkování patří našim dobrovolným překladatelům: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Ángela Graña (es), Doron Barak (on), Ruth Levy (on), Joanna Klopotek (pl), Tania Bassi ( pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
     <string name="latest_videos">Nejnovější videa</string>
     <string name="donate">Darovat</string>
     <string name="subscribe">Předplatit si</string>
@@ -49,12 +49,12 @@
     <string name="back_to_today">Zpět na Dnes</string>
     <string name="debug">Ladit</string>
     <string name="debug_clear_data">Vymazat všechna data</string>
-    <string name="debug_clear_data_message">Tímto se vymažou všechny zadané porce Denní Dvanáctky. Přejete si pokračovat?</string>
+    <string name="debug_clear_data_message">Tímto se vymažou všechny zadané porce. Přejete si pokračovat?</string>
     <string name="OK">OK</string>
     <string name="dialog_streaks_title">Nová funkce: Grafy!</string>
     <string name="dialog_streaks_message">Vaše databáze bude nyní upgradována, aby podporovala novou funkci Grafy</string>
     <string name="dialog_no_email_apps_title">Nebyla nalezena e-mailové aplikace</string>
-    <string name="dialog_no_email_apps_message">Zálohování dat vyžaduje, abyste měli nainstalovanou e-mailovou aplikaci, abyste si mohli poslat e-mailem záložní soubor .csv. Nainstalujte si e-mailovou aplikaci a zkuste to znovu.</string>
+    <string name="dialog_no_email_apps_message">Zálohování dat vyžaduje, abyste měli nainstalovanou e-mailovou aplikaci, abyste si mohli poslat e-mailem záložní soubor. Nainstalujte si e-mailovou aplikaci a zkuste to znovu.</string>
     <string name="debug_generate_random_data">Generovat náhodná data</string>
     <string name="debug_generate_full_data">Vygenerujte úplná data</string>
     <string name="debug_generate_data_message">Všechna stávající data budou nahrazena. Přejete si pokračovat?</string>
@@ -70,7 +70,7 @@
     <string name="not_now">Nyní ne</string>
     <string name="format_version">verze %s</string>
     <string name="format_num_days">%d dnů</string>
-    <string name="daily_reminder_title">Denní Dvanátka - připomenutí</string>
+    <string name="daily_reminder_title">Denní Dvanáctka - připomenutí</string>
     <string name="daily_reminder_text">Aktualizujte své porce pro dnešek</string>
     <string name="daily_reminder_settings">Nastavení denního připomenutí</string>
     <string name="enable_daily_reminder">Povolit denní připomenutí</string>
@@ -81,9 +81,9 @@
     <string name="metric">Metrické</string>
     <string name="error_cannot_handle_url">Nelze otevřít adresu URL. Nainstalujte si prosím prohlížeč.</string>
     <string name="channel_reminders_name">Připomenutí</string>
-    <string name="twenty_one_tweaks">Jednadvacítka Hubnutí</string>
-    <string name="tweaks">Jednadvacítka Hubnutí</string>
-    <string name="daily_tweaks_history">Denní historie Jednadvacítky Hubnutí</string>
+    <string name="twenty_one_tweaks">21 Hubnutí</string>
+    <string name="tweaks">21 Hubnutí</string>
+    <string name="daily_tweaks_history">Denní historie 21 Hubnutí</string>
     <string name="weight_history">Historie hmotnosti</string>
     <string name="no_weights_recorded">Dosud jste nezaznamenali žádnou váhu!</string>
     <string name="task_loading_weights_history_title">Stahování historie váhy</string>
@@ -135,12 +135,12 @@
     <string name="nightly_trendelenburg_short">Experimentujte s mírnou Trendelenburgovo polohou</string>
     <string name="meal_water_text">Načasujte si vypití dvou šálků studené neochucené vody před každým jídlem na zrychlení metabolismu, abyste také využili výhody předplnění se vodou.</string>
     <string name="meal_negcal_text">Jako první chod začněte každé jídlo jablkem nebo polévkou nebo salátem Green Light s méně než 100 kaloriemi na šálek.</string>
-    <string name="meal_vinegar_text">Nikdy nepijte čistý ocet. Místo toho používejte kterýkoli z dostupných octů (sladkých i \"slaných\") k dochucení jídla, nebo pokapání přílohového salátu. Pokud jej pít chcete, nezapomeňte jej naředit ve sklenici s vodou a po požití si důkladně vypláchněte ústa, abyste ochránili zubní sklovinu.</string>
+    <string name="meal_vinegar_text">Nikdy nepijte čistý ocet. Místo toho používejte kterýkoli z dostupných octů (sladkých i „slaných“) k dochucení jídla, nebo pokapání přílohového salátu. Pokud jej pít chcete, nezapomeňte jej naředit ve sklenici s vodou a po požití si důkladně vypláchněte ústa, abyste ochránili zubní sklovinu.</string>
     <string name="meal_undistracted_text">Nesledujte televizi a nepoužívejte telefon při jídle. Zaškrtněte si políčko za každé jídlo, které dokážete sníst bez rozptylování.</string>
     <string name="meal_twentyminutes_text">Ať už zvýšením viskozity nebo počtu žvýkání nebo snížením velikosti sousta a rychlosti jedení, desítky studií prokázaly, že bez ohledu na to, jak zvýšíme dobu, po kterou je jídlo v našich ústech, může to vést k nižšímu kalorickému příjmu. Prodlužte tedy dobu jídla alespoň na dvacet minut, aby se vaše přirozené signály sytosti mohly plně projevit. Jak? Výběrem potravin, jejichž konzumace trvá déle, a jejich konzumací způsobem, který prodlouží dobu, po kterou zůstanou v ústech. Jezte objemnější, tužší nebo potraviny nutné žvýkat, v malých, pořádně rozžvýkaných soustech.</string>
     <string name="daily_blackcumin_text">Jak je uvedeno v části Potlačení chuti k jídlu, systematický přehled a metaanalýza randomizovaných, kontrolovaných studií hubnutí zjistila, že asi čtvrtina čajové lžičky prášku z černého kmínu každý den snižuje index tělesné hmotnosti během několika měsíců. Všimněte si, že černý kmín se liší od běžného kmínu, u kterého se liší dávkování.</string>
     <string name="daily_garlic_text">Randomizované, dvojitě zaslepené, placebem kontrolované studie zjistily, že jen čtvrt čajové lžičky česnekového prášku denně může snížit tělesný tuk za cenu pár centů denně.</string>
-    <string name="daily_ginger_text">Randomizované kontrolované studie zjistily, že ¼ lžičky až 1½ lžičky mletého zázvoru denně významně snižuje tělesnou hmotnost, za cenu pouhých haléřů. Může to být tak jednoduché, jako zamíchat lžičku mletého koření do šálku horké vody. Poznámka: zázvor může lépe působit ráno, než večer. Čaj Chai je chutný způsob, jak spojit trik s kořením a trik se zeleným čajem do jediného nápoje. Alternativně, pro aktivaci BAT, můžete do své každodenní stravy přidat jednu syrovou jalapeño papričku, nebo půl lžičky prášku z červené papriky (případně také nadrcené paprikové vločky). Pro snížení pálivosti je možné jalapeño nakrájet na velmi tenké plátky, nebo nadrobno nasekat - to zredukuje pálení na jemné škrabkání - nebo vmíchejte papriku do \"celého jídla ve formě zeleninového smoothie\", které uvádím v jednom ze svých videí o vaření na stránkách NutritionFacts.org</string>
+    <string name="daily_ginger_text">Randomizované kontrolované studie zjistily, že ¼ lžičky až 1½ lžičky mletého zázvoru denně významně snižuje tělesnou hmotnost, za cenu pouhých haléřů. Může to být tak jednoduché, jako zamíchat lžičku mletého koření do šálku horké vody. Poznámka: zázvor může lépe působit ráno, než večer. Čaj Chai je chutný způsob, jak spojit trik s kořením a trik se zeleným čajem do jediného nápoje. Alternativně, pro aktivaci BAT, můžete do své každodenní stravy přidat jednu syrovou jalapeño papričku, nebo půl lžičky prášku z červené papriky (případně také nadrcené paprikové vločky). Pro snížení pálivosti je možné jalapeño nakrájet na velmi tenké plátky, nebo nadrobno nasekat - to zredukuje pálení na jemné škrabkání - nebo vmíchejte papriku do „celého jídla ve formě zeleninového smoothie“, které uvádím v jednom ze svých videí o vaření na stránkách NutritionFacts.org</string>
     <string name="daily_nutriyeast_text">Dvě čajové lžičky pekařského, pivovarského nebo lahůdkového droždí obsahují zhruba takové množství beta 1,3/1,6 glukanů, jaké bylo nalezeno v randomizovaných, dvojitě zaslepených, placebem kontrolovaných klinických studiích pro usnadnění hubnutí.</string>
     <string name="daily_cumin_text">Ženy s nadváhou náhodně vybrané do skupiny, která si k obědu a večeři dávala navíc půl lžičky římského kmínu, zhubly oproti kontrolní skupině o 4 kila a palec (2,5cm) v pase více. Existují také důkazy ohledně stejné účinnosti šafránu (koření), toho by ale špetka denně stála dolar, zatímco lžička římského kmínu stojí méně než deset centů.</string>
     <string name="daily_greentea_text">Pijte tři šálky denně mezi jídly (počkejte alespoň hodinu po jídle, abyste nenarušili vstřebávání železa). Během jídla pijte vodu nebo ibiškový čaj smíchaný v poměru 6:1 s citronovou verbenou, ale nikdy nepřekračujte tři šálky tekutiny za hodinu (důležité vzhledem k mé radě ohledně předběžného naplnění vodou). Využijte posilujícího účinku kofeinu tím, že budete pít svůj zelený čaj spolu s něčím zdravým, co si přejete, aby vám chutnalo víc, ale nekonzumujte velké množství kofeinu šest hodin před spaním. Nejlepší je pít čaj bez sladidla, ale pokud si čaj obvykle sladíte medem nebo cukrem, zkuste místo toho jakonový sirup.</string>
@@ -159,7 +159,7 @@
     <string name="tweak_group_daily">Každý den</string>
     <string name="tweak_group_dailydoses">Vezměte si své denní porce</string>
     <string name="tweak_group_nightly">Každou noc</string>
-    <string name="about_tweak">O Jednadacítce Hubnutí</string>
+    <string name="about_tweak">O 21 Hubnutí</string>
     <string-array name="about_text_lines">
         <item>Tuto aplikaci vytvořil John Slavick.</item>
         <item />
@@ -174,7 +174,7 @@
         <item />
         <item>2. Klepněte na záložní soubor připojený k tomuto e-mailu.</item>
         <item />
-        <item>3. Vyberte Otevřít s Denní dvanáctkou</item>
+        <item>3. Vyberte Otevřít s Denní Dvanáctkou</item>
     </string-array>
     <string-array name="servings_time_scale_choices">
         <item>Den</item>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -24,7 +24,7 @@
     <string name="moving_average">Gleitender Mittelwert</string>
     <string name="about">Über</string>
     <string name="about_this_app">Über diese Anwendung</string>
-    <string name="about_translators">Besonderer Dank an unsere ehrenamtlichen Übersetzer: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), Joao Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
+    <string name="about_translators">Besonderer Dank an unsere ehrenamtlichen Übersetzer: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Ángela Graña (es), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), Joao Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
     <string name="latest_videos">Neueste Videos</string>
     <string name="donate">Spenden Sie</string>
     <string name="subscribe">Abonnieren</string>
@@ -54,7 +54,7 @@
     <string name="dialog_streaks_title">Neue Fortschrittsfunktion hinzugefügt!</string>
     <string name="dialog_streaks_message">Ihre Datenbank wird nun aktualisiert, um die neue Fortschrittsfunktion zu unterstützen.</string>
     <string name="dialog_no_email_apps_title">Keine E-Mail-Anwendungen gefunden</string>
-    <string name="dialog_no_email_apps_message">Um Ihre Daten zu sichern, müssen Sie eine E-Mail-Anwendung installieren, damit Sie sich die .csv-Sicherungsdatei per E-Mail zusenden können. Bitte installieren Sie eine E-Mail-Anwendung und versuchen Sie es erneut.</string>
+    <string name="dialog_no_email_apps_message">Um Ihre Daten zu sichern, müssen Sie eine E-Mail-Anwendung installieren, damit Sie sich die Sicherungsdatei per E-Mail zusenden können. Bitte installieren Sie eine E-Mail-Anwendung und versuchen Sie es erneut.</string>
     <string name="debug_generate_random_data">Zufallsdaten erzeugen</string>
     <string name="debug_generate_full_data">Vollständige Daten erzeugen</string>
     <string name="debug_generate_data_message">Alle vorhandenen Daten werden ersetzt. Möchten Sie fortfahren?</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -24,7 +24,7 @@
     <string name="moving_average">Κινητός Μέσος Όρος</string>
     <string name="about">Σχετικά</string>
     <string name="about_this_app">Σχετικά με την εφαρμογή</string>
-    <string name="about_translators">Ιδιαίτερες ευχαριστίες στους εθελοντές μεταφραστές μας: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
+    <string name="about_translators">Ιδιαίτερες ευχαριστίες στους εθελοντές μεταφραστές μας: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Ángela Graña (es), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
     <string name="latest_videos">Τελευταία Βίντεο</string>
     <string name="donate">Δωρεά</string>
     <string name="subscribe">Εγγραφή</string>
@@ -54,7 +54,7 @@
     <string name="dialog_streaks_title">Νέα λειτουργία: Σερί!</string>
     <string name="dialog_streaks_message">Η βάση δεδομένων σας θα πρέπει τώρα να αναβαθμιστεί για να υποστηρίζει τη νέα λειτουργία για τα σερί.</string>
     <string name="dialog_no_email_apps_title">Δεν βρέθηκαν εφαρμογές ηλεκτρονικού ταχυδρομείου</string>
-    <string name="dialog_no_email_apps_message">Η δημιουργία αντιγράφων ασφαλείας των δεδομένων σας απαιτεί να έχετε εγκαταστήσει μια εφαρμογή ηλεκτρονικού ταχυδρομείου, ώστε να μπορείτε να στείλετε το αρχείο .csv αντιγράφων ασφαλείας στον εαυτό σας. Παρακαλώ εγκαταστήστε μια εφαρμογή ηλεκτρονικού ταχυδρομείου και δοκιμάστε ξανά.</string>
+    <string name="dialog_no_email_apps_message">Η δημιουργία αντιγράφων ασφαλείας των δεδομένων σας απαιτεί να έχετε εγκαταστήσει μια εφαρμογή ηλεκτρονικού ταχυδρομείου, ώστε να μπορείτε να στείλετε το αρχείο αντιγράφων ασφαλείας στον εαυτό σας. Παρακαλώ εγκαταστήστε μια εφαρμογή ηλεκτρονικού ταχυδρομείου και δοκιμάστε ξανά.</string>
     <string name="debug_generate_random_data">Παραγωγή τυχαίων δεδομένων</string>
     <string name="debug_generate_full_data">Παραγωγή πλήρων στοιχείων</string>
     <string name="debug_generate_data_message">Όλα τα υπάρχοντα δεδομένα θα αντικατασταθούν. Θέλετε να συνεχίσετε;</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -24,7 +24,7 @@
     <string name="moving_average">Media móvil</string>
     <string name="about">Conócenos</string>
     <string name="about_this_app">Sobre esta app</string>
-    <string name="about_translators">Le damos las gracias a nuestros traductores voluntarios: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru), Ángela Graña (es).</string>
+    <string name="about_translators">Le damos las gracias a nuestros traductores voluntarios: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Ángela Graña (es), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
     <string name="latest_videos">Videos más recientes</string>
     <string name="donate">Donación</string>
     <string name="subscribe">Suscríbete</string>
@@ -54,7 +54,7 @@
     <string name="dialog_streaks_title">Nueva característica: ¡Rachas!</string>
     <string name="dialog_streaks_message">Se actualizará la base de datos para incluir la nueva característica de rachas.</string>
     <string name="dialog_no_email_apps_title">No se encontró ninguna aplicación de correo electrónico</string>
-    <string name="dialog_no_email_apps_message">Para crear una copia de seguridad, debes tener una aplicación de correo electrónico instalada, lo que te permitirá mandarte a ti mismo el archivo .csv por email. Instala una applicación de correo electrónico e inténtalo de nuevo.</string>
+    <string name="dialog_no_email_apps_message">Para crear una copia de seguridad, debes tener una aplicación de correo electrónico instalada, lo que te permitirá mandarte a ti mismo el archivo por email. Instala una applicación de correo electrónico e inténtalo de nuevo.</string>
     <string name="debug_generate_random_data">Generar datos al azar</string>
     <string name="debug_generate_full_data">Generar datos completos</string>
     <string name="debug_generate_data_message">Todos los datos existentes serán reemplazados. ¿Deseas continuar?</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -24,7 +24,7 @@
     <string name="moving_average">Moyenne mobile</string>
     <string name="about">À propos</string>
     <string name="about_this_app">À propos de cette application</string>
-    <string name="about_translators">Remerciements particuliers à nos traducteurs bénévoles : Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
+    <string name="about_translators">Remerciements particuliers à nos traducteurs bénévoles : Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Ángela Graña (es), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
     <string name="latest_videos">Dernières vidéos</string>
     <string name="donate">Faire un don</string>
     <string name="subscribe">Souscrire</string>
@@ -54,7 +54,7 @@
     <string name="dialog_streaks_title">Nouvelle fonctionnalité: Tendances!</string>
     <string name="dialog_streaks_message">Votre base de données sera maintenant mise à niveau pour prendre en charge la nouvelle fonctionnalité des tendances.</string>
     <string name="dialog_no_email_apps_title">Aucune application de messagerie électronique trouvée</string>
-    <string name="dialog_no_email_apps_message">Pour sauvegarder vos données, vous devez disposer d\'une application de messagerie électronique pour que vous puissiez envoyer par courriel le fichier de sauvegarde .csv. Veuillez installer une application de messagerie et réessayer.</string>
+    <string name="dialog_no_email_apps_message">Pour sauvegarder vos données, vous devez disposer d\'une application de messagerie électronique pour que vous puissiez envoyer par courriel le fichier de sauvegarde. Veuillez installer une application de messagerie et réessayer.</string>
     <string name="debug_generate_random_data">Générer des données aléatoires</string>
     <string name="debug_generate_full_data">Générer des données complètes</string>
     <string name="debug_generate_data_message">Toutes les données existantes seront remplacées. Souhaitez-vous continuer?</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -24,7 +24,7 @@
     <string name="moving_average">ממוצע נע</string>
     <string name="about">לגבי</string>
     <string name="about_this_app">בקשר לאפליקציה זו</string>
-    <string name="about_translators">תודה מיוחדת למתרגמים המתנדבים: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru). </string>
+    <string name="about_translators">תודה מיוחדת למתרגמים המתנדבים: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Ángela Graña (es), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru). </string>
     <string name="latest_videos">הסרטונים האחרונים</string>
     <string name="donate">תירמו</string>
     <string name="subscribe">הירשמו</string>
@@ -54,7 +54,7 @@
     <string name="dialog_streaks_title">תכונה חדשה: התקדמות!</string>
     <string name="dialog_streaks_message">מסד הנתונים שלכם ישודרג כעת לתמיכה בתכונת ההתקדמות החדשה.</string>
     <string name="dialog_no_email_apps_title">לא נמצאה אפליקציית email</string>
-    <string name="dialog_no_email_apps_message">גיבוי הנתונים שלכם מחייב התקנת יישום דוא\"ל כדי שתוכלו לשלוח לעצמכם את קובץ הגיבוי .csv בדוא\"ל. התקן יישום דוא\"ל ונסה שוב.</string>
+    <string name="dialog_no_email_apps_message">גיבוי הנתונים שלכם מחייב התקנת יישום דוא\"ל כדי שתוכלו לשלוח לעצמכם את קובץ הגיבוי בדוא\"ל. התקן יישום דוא\"ל ונסה שוב.</string>
     <string name="debug_generate_random_data">יצירת נתונים אקראיים</string>
     <string name="debug_generate_full_data">יצירת נתונים מלאים</string>
     <string name="debug_generate_data_message">כל הנתונים הקיימים יוחלפו. האם אתם רוצים להמשיך?</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -24,7 +24,7 @@
     <string name="moving_average">Media Mobile</string>
     <string name="about">Informazioni</string>
     <string name="about_this_app">Informazioni sull\'app</string>
-    <string name="about_translators">Un ringraziamento speciale ai nostri traduttori volontari: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
+    <string name="about_translators">Un ringraziamento speciale ai nostri traduttori volontari: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Ángela Graña (es), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
     <string name="latest_videos">Ultimi Video</string>
     <string name="donate">Dona ora</string>
     <string name="subscribe">Iscriviti</string>
@@ -54,7 +54,7 @@
     <string name="dialog_streaks_title">Nuova funzione: Serie!</string>
     <string name="dialog_streaks_message">Il database sarà ora aggiornato per supportare la nuova funzionalità Serie.</string>
     <string name="dialog_no_email_apps_title">Nessuna applicazione di posta elettronica trovata</string>
-    <string name="dialog_no_email_apps_message">Per effettuare il backup dei dati si richiede di avere un app di posta elettronica installata in modo da poter inviare il file di backup .csv al tuo indirizzo. Installa un\'applicazione di posta elettronica e riprova.</string>
+    <string name="dialog_no_email_apps_message">Per effettuare il backup dei dati si richiede di avere un app di posta elettronica installata in modo da poter inviare il file di backup al tuo indirizzo. Installa un\'applicazione di posta elettronica e riprova.</string>
     <string name="debug_generate_random_data">Genera dati casuali</string>
     <string name="debug_generate_full_data">Genera dati completi</string>
     <string name="debug_generate_data_message">Tutti i dati esistenti verranno sostituiti. Vuoi continuare?</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -24,7 +24,7 @@
     <string name="moving_average">ממוצע נע</string>
     <string name="about">לגבי</string>
     <string name="about_this_app">בקשר לאפליקציה זו</string>
-    <string name="about_translators">תודה מיוחדת למתרגמים המתנדבים: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru). </string>
+    <string name="about_translators">תודה מיוחדת למתרגמים המתנדבים: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Ángela Graña (es), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru). </string>
     <string name="latest_videos">הסרטונים האחרונים</string>
     <string name="donate">תירמו</string>
     <string name="subscribe">הירשמו</string>
@@ -54,7 +54,7 @@
     <string name="dialog_streaks_title">תכונה חדשה: התקדמות!</string>
     <string name="dialog_streaks_message">מסד הנתונים שלכם ישודרג כעת לתמיכה בתכונת ההתקדמות החדשה.</string>
     <string name="dialog_no_email_apps_title">לא נמצאה אפליקציית email</string>
-    <string name="dialog_no_email_apps_message">גיבוי הנתונים שלכם מחייב התקנת יישום דוא\"ל כדי שתוכלו לשלוח לעצמכם את קובץ הגיבוי .csv בדוא\"ל. התקן יישום דוא\"ל ונסה שוב.</string>
+    <string name="dialog_no_email_apps_message">גיבוי הנתונים שלכם מחייב התקנת יישום דוא\"ל כדי שתוכלו לשלוח לעצמכם את קובץ הגיבוי בדוא\"ל. התקן יישום דוא\"ל ונסה שוב.</string>
     <string name="debug_generate_random_data">יצירת נתונים אקראיים</string>
     <string name="debug_generate_full_data">יצירת נתונים מלאים</string>
     <string name="debug_generate_data_message">כל הנתונים הקיימים יוחלפו. האם אתם רוצים להמשיך?</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -24,7 +24,7 @@
     <string name="moving_average">Średnia ruchoma</string>
     <string name="about">O aplikacji</string>
     <string name="about_this_app">O aplikacji</string>
-    <string name="about_translators">Specjalne podziękowania dla naszych tłumaczy-wolontariuszy: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Doron Barak (he), Ruth Levy (he), Hanna Gurzeda (pl), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
+    <string name="about_translators">Specjalne podziękowania dla naszych tłumaczy-wolontariuszy: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Ángela Graña (es), Doron Barak (he), Ruth Levy (he), Hanna Gurzeda (pl), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
     <string name="latest_videos">Najnowsze filmy</string>
     <string name="donate">Donacja</string>
     <string name="subscribe">Subskrybuj</string>
@@ -54,7 +54,7 @@
     <string name="dialog_streaks_title">Dodano nową funkcję postępu!</string>
     <string name="dialog_streaks_message">Twoja baza danych zostanie uaktualniona by wspierać nową funkcję postępu.</string>
     <string name="dialog_no_email_apps_title">Nie znaleziono aplikacji poczty e-mail</string>
-    <string name="dialog_no_email_apps_message">Tworzenie kopii zapasowych twoich danych wymaga zainstalowania aplikacji do obsługi poczty e-mail, aby można było wysłać do siebie plik kopii zapasowej “.csv” . Zainstaluj aplikację e-mail i spróbuj ponownie.</string>
+    <string name="dialog_no_email_apps_message">Tworzenie kopii zapasowych twoich danych wymaga zainstalowania aplikacji do obsługi poczty e-mail, aby można było wysłać do siebie plik kopii zapasowej. Zainstaluj aplikację e-mail i spróbuj ponownie.</string>
     <string name="debug_generate_random_data">Wygeneruj losowe dane</string>
     <string name="debug_generate_full_data">Wygeneruj wszystie dane</string>
     <string name="debug_generate_data_message">Wszystkie istniejące dane zostaną zastąpione. Czy chcesz kontynuować?</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -24,7 +24,7 @@
     <string name="moving_average">Média Móvel</string>
     <string name="about">Sobre Nós</string>
     <string name="about_this_app">Sobre este aplicativo</string>
-    <string name="about_translators">Agradecimentos especiais aos nossos tradutores voluntários: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
+    <string name="about_translators">Agradecimentos especiais aos nossos tradutores voluntários: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Ángela Graña (es), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
     <string name="latest_videos">Últimos Vídeos</string>
     <string name="donate">Doar</string>
     <string name="subscribe">Inscreva-se</string>
@@ -54,7 +54,7 @@
     <string name="dialog_streaks_title">Nova função de progresso adicionada!</string>
     <string name="dialog_streaks_message">A sua base de dados não será atualizada para suportar a nova função de progresso.</string>
     <string name="dialog_no_email_apps_title">Aplicativo de email não encontrado</string>
-    <string name="dialog_no_email_apps_message">Fazer uma cópia de segurança das suas informações requer que você tenha um aplicativo de email instalado para que você possa enviar por email o arquivo .csv para você mesmo. Por favor instale um aplicativo de email e tente novamente.</string>
+    <string name="dialog_no_email_apps_message">Fazer uma cópia de segurança das suas informações requer que você tenha um aplicativo de email instalado para que você possa enviar por email o arquivo para você mesmo. Por favor instale um aplicativo de email e tente novamente.</string>
     <string name="debug_generate_random_data">Gerar informações aleatórias</string>
     <string name="debug_generate_full_data">Gerar informações completas</string>
     <string name="debug_generate_data_message">Todos os dados existentes serão substituidos. Deseja continuar?</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -24,7 +24,7 @@
     <string name="moving_average">Média Móvel</string>
     <string name="about">Sobre Nós</string>
     <string name="about_this_app">Sobre este aplicativo</string>
-    <string name="about_translators">Agradecimentos especiais aos tradutores voluntários: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
+    <string name="about_translators">Agradecimentos especiais aos tradutores voluntários: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Ángela Graña (es), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
     <string name="latest_videos">Últimos Vídeos</string>
     <string name="donate">Doar</string>
     <string name="subscribe">Subscreva</string>
@@ -54,7 +54,7 @@
     <string name="dialog_streaks_title">Nova função de progresso adicionada!</string>
     <string name="dialog_streaks_message">A sua base de dados será agora atualizada para suportar a nova função de progresso.</string>
     <string name="dialog_no_email_apps_title">Aplicativo de email não encontrado</string>
-    <string name="dialog_no_email_apps_message">Fazer uma cópia de segurança das suas informações requer que você tenha um aplicativo de email instalado para que você possa enviar, por email, o arquivo .csv para você mesmo. Por favor instale um aplicativo de email e tente novamente.</string>
+    <string name="dialog_no_email_apps_message">Fazer uma cópia de segurança das suas informações requer que você tenha um aplicativo de email instalado para que você possa enviar, por email, o arquivo para você mesmo. Por favor instale um aplicativo de email e tente novamente.</string>
     <string name="debug_generate_random_data">Gerar informações aleatórias</string>
     <string name="debug_generate_full_data">Gerar informações completas</string>
     <string name="debug_generate_data_message">Todos os dados existentes serão substituidos. Deseja continuar?</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -24,7 +24,7 @@
     <string name="moving_average">Media mișcării</string>
     <string name="about">Despre</string>
     <string name="about_this_app">Despre această aplicație</string>
-    <string name="about_translators">Mulțumiri speciale traducătorilor noștri voluntari: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
+    <string name="about_translators">Mulțumiri speciale traducătorilor noștri voluntari: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Ángela Graña (es), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
     <string name="latest_videos">Ultimele videoclipuri</string>
     <string name="donate">Donați</string>
     <string name="subscribe">Abonați-vă</string>
@@ -54,7 +54,7 @@
     <string name="dialog_streaks_title">Caracteristică nouă: Secvenţe consecutive!</string>
     <string name="dialog_streaks_message">Baza dvs. de date va fi acum actualizată pentru a accepta caracteristica nouă de secvenţe consecutive.</string>
     <string name="dialog_no_email_apps_title">Nu au fost găsite aplicații de e-mail</string>
-    <string name="dialog_no_email_apps_message">Copia de rezervă a datelor dvs. necesită instalarea unei aplicații de e-mail, astfel încât să puteți trimite fișierul de rezervă .csv prin e-mail. Instalați o aplicație de e-mail și încercați din nou.</string>
+    <string name="dialog_no_email_apps_message">Copia de rezervă a datelor dvs. necesită instalarea unei aplicații de e-mail, astfel încât să puteți trimite fișierul de rezervă prin e-mail. Instalați o aplicație de e-mail și încercați din nou.</string>
     <string name="debug_generate_random_data">Generează date aleatorii</string>
     <string name="debug_generate_full_data">Generează date complete</string>
     <string name="debug_generate_data_message">Toate datele existente vor fi înlocuite. Doriți să continuați?</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -24,7 +24,7 @@
     <string name="moving_average">Средняя подвижность</string>
     <string name="about">О нас</string>
     <string name="about_this_app">Об этом приложении</string>
-    <string name="about_translators">Особая благодарность нашим переводчикам-волонтерам: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
+    <string name="about_translators">Особая благодарность нашим переводчикам-волонтерам: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Ángela Graña (es), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
     <string name="latest_videos">Последние видео</string>
     <string name="donate">Сделайте пожертвование</string>
     <string name="subscribe">Подпишитесь</string>
@@ -54,7 +54,7 @@
     <string name="dialog_streaks_title">Новая функциональность, отображающая прогресс, была добавлена!</string>
     <string name="dialog_streaks_message">Ваша база данных сейчас будет обновлена до версии, поддерживающей новую функциональность прогресса.</string>
     <string name="dialog_no_email_apps_title">Не было найдено ни одного приложения для работы с электронной почтой.</string>
-    <string name="dialog_no_email_apps_message">Чтобы создать резервную копию ваших данных, вам нужно сначала установить приложение для работы с электронной почтой, чтобы вы смогли послать себе .csv файл с резервной копией. Пожалуйста, попробуйте установить приложение и повторите попытку.</string>
+    <string name="dialog_no_email_apps_message">Чтобы создать резервную копию ваших данных, вам нужно сначала установить приложение для работы с электронной почтой, чтобы вы смогли послать себе файл с резервной копией. Пожалуйста, попробуйте установить приложение и повторите попытку.</string>
     <string name="debug_generate_random_data">Получить случайную выборку</string>
     <string name="debug_generate_full_data">Получить все данные</string>
     <string name="debug_generate_data_message">Все существующие данные будут изменены. Вы хотите продолжить?</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -24,7 +24,7 @@
     <string name="moving_average">移動平均數</string>
     <string name="about">關於我們</string>
     <string name="about_this_app">關於這個應用程式</string>
-    <string name="about_translators">特別鳴謝翻譯志願者：Ricard Soler Roger（ca）、Luděk Bouška（cs）、Lenka Lukacová（cs）、Anke Schliessmann（de）、Doron Barak（he）、Ruth Levy（he）、Joanna Klopotek（pl）、Tania Bassi（pt-BR）、João Madureira（pr-PT）、Evgeniya Lyakh（ru）。</string>
+    <string name="about_translators">特別鳴謝翻譯志願者：Ricard Soler Roger（ca）、Luděk Bouška（cs）、Lenka Lukacová（cs）、Anke Schliessmann（de）、Ángela Graña（es）、Doron Barak（he）、Ruth Levy（he）、Joanna Klopotek（pl）、Tania Bassi（pt-BR）、João Madureira（pr-PT）、Evgeniya Lyakh（ru）。</string>
     <string name="latest_videos">最新影片</string>
     <string name="donate">捐款</string>
     <string name="subscribe">訂閱</string>
@@ -54,7 +54,7 @@
     <string name="dialog_streaks_title">新功能：趨勢圖</string>
     <string name="dialog_streaks_message">現在將升級您的資料庫，以支持新的趨勢圖功能。</string>
     <string name="dialog_no_email_apps_title">找不到電子郵件應用程式</string>
-    <string name="dialog_no_email_apps_message">您需要安裝電子郵件應用程式才能使用備份數據功能，才能將.csv的備份檔案寄到自己的電子郵件信箱。請安裝電子郵件應用程式後再重試。</string>
+    <string name="dialog_no_email_apps_message">您需要安裝電子郵件應用程式才能使用備份數據功能，才能將的備份檔案寄到自己的電子郵件信箱。請安裝電子郵件應用程式後再重試。</string>
     <string name="debug_generate_random_data">產生隨機數據</string>
     <string name="debug_generate_full_data">產生完整數據</string>
     <string name="debug_generate_data_message">所有現存的數據都將被取代。確定要繼續嗎？</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="moving_average">Moving Average</string>
     <string name="about">About</string>
     <string name="about_this_app">About this app</string>
-    <string name="about_translators">Special thanks to our volunteer translators: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
+    <string name="about_translators">Special thanks to our volunteer translators: Ricard Soler Roger (ca), Luděk Bouška (cs), Lenka Lukacová (cs), Anke Schliessmann (de), Ángela Graña (es), Doron Barak (he), Ruth Levy (he), Joanna Klopotek (pl), Tania Bassi (pt-BR), João Madureira (pt-PT), Evgeniya Lyakh (ru).</string>
     <string name="latest_videos">Latest Videos</string>
     <string name="url_latest_videos" translatable="false">http://nutritionfacts.org/videos/</string>
     <string name="title_how_not_to_die" translatable="false">How Not to Die</string>
@@ -85,7 +85,7 @@
     <string name="dialog_streaks_title">New feature: Streaks!</string>
     <string name="dialog_streaks_message">Your database will now be upgraded to support the new streaks feature.</string>
     <string name="dialog_no_email_apps_title">No email apps found</string>
-    <string name="dialog_no_email_apps_message">Backing up your data requires you to have an email app installed so you can email the .csv backup file to yourself. Please install an email app and try again.</string>
+    <string name="dialog_no_email_apps_message">Backing up your data requires you to have an email app installed so you can email the backup file to yourself. Please install an email app and try again.</string>
     <string name="debug_generate_random_data">Generate random data</string>
     <string name="debug_generate_full_data">Generate full data</string>
     <string name="debug_generate_data_message">All existing data will be replaced. Do you wish to continue?</string>


### PR DESCRIPTION

1. Czech update. In particular, "21 Tweaks" in Czech has been [resolved to "21 hubnutí"](https://github.com/nutritionfactsorg/daily-dozen-localization/issues/26#issuecomment-1324789308)
2. Simplified "the .cvs backup file" to be generic "the backup file". (Side note: backup format had been changed to .json instead of .csv.)
3. Updated contributor list.