### PR TITLE
Fix daily reminder time parsing issue in Canada

### DIFF
--- a/app/src/main/java/org/nutritionfacts/dailydozen/model/pref/UpdateReminderPref.java
+++ b/app/src/main/java/org/nutritionfacts/dailydozen/model/pref/UpdateReminderPref.java
@@ -148,6 +148,14 @@ public class UpdateReminderPref {
                     return (int) date.getTime();
                 }
             } catch (ParseException e) {
+                // If Canada Locale, AM/PM needs to be replaced with a.m./p.m. otherwise the time will not parse
+                // So if we get a ParseException, try replacing AM/PM with a.m./p.m. and try again
+                if (time.contains("AM") || time.contains("PM")) {
+                    time = time.replace("AM", "a.m.").replace("PM", "p.m.");
+                    return timeInMillis(time, format);
+                }
+
+                // If the time still doesn't parse, try the twenty four hour format
                 if (format != twentyFourHourFormat) {
                     return timeInMillis(time, twentyFourHourFormat);
                 } else {


### PR DESCRIPTION
This PR fixes an issue causing daily reminder notifications to not show at the correct time for users in Canada.

The problem is the time "8:00 PM" does not parse correctly in Canada as the locale requires am/pm labels to be in the format "a.m./p.m."