### PR TITLE
Persian: fixes food_info_types_nuts sequence 8 to 13 (Peanuts … Walnuts)

### DIFF
--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -327,13 +327,13 @@
         <item>فندق</item>
         <item>شاهدانه</item>
         <item>فندقِ خامه‌ای/فندقِ ماکادامیا/فندقِ استرالیایی</item>
+        <item>بادام‌زمینی</item>
         <item>گردوی آمریکایی/پِکان</item>
         <item>پسته</item>
         <item>تخمه‌کدو</item>
         <item>کنجد</item>
         <item>تخمه‌آفتابگردان</item>
         <item>گردو</item>
-        <item>Walnuts</item>
     </string-array>
     <string-array name="food_info_types_spices">
         <item>فلفلِ رنگی</item>


### PR DESCRIPTION
The translation spreadsheet used for Persian did not have the correct Android indices for `food_info_types_nuts`. In this case Peanuts was missing and Walnuts was appearing in English.

![Peanuts to Walnuts](https://github.com/nutritionfactsorg/daily-dozen-android/assets/15098151/1b888c1f-29bb-469d-8fc5-254c6a2cf0c9)

Something that was not caught in updating the spreadsheets for localization ChangeSet05.

- [ChangeSet05: add "Peanuts" to "Nuts and Seeds" #40](https://github.com/nutritionfactsorg/daily-dozen-localization/issues/40)

The Persian translation spreadsheets have been updated in `daily-dozen-localization`. https://github.com/nutritionfactsorg/daily-dozen-localization/commit/67a1804ce73c270e17779849242c28ad5081d1f0

This pull request updates the Android `strings.xml` downstream from the now updated Persian spreadsheet.
