### PR TITLE
fix: add timestamp to backup filename

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,10 +45,10 @@
 
                 <data
                     android:mimeType="text/csv"
-                    android:pathPattern="dailydozen_backup_\\.csv"/>
+                    android:pathPattern=".*dailydozen_backup.*\\.csv"/>
                 <data
                     android:mimeType="application/json"
-                    android:pathPattern="dailydozen_backup_\\.json"/>
+                    android:pathPattern=".*dailydozen_backup.*\\.json"/>
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/org/nutritionfacts/dailydozen/activity/MainActivity.java
+++ b/app/src/main/java/org/nutritionfacts/dailydozen/activity/MainActivity.java
@@ -39,8 +39,10 @@ import org.nutritionfacts.dailydozen.util.DateUtil;
 import org.nutritionfacts.dailydozen.util.NotificationUtil;
 
 import java.io.File;
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.util.Date;
+import java.util.Locale;
 
 import timber.log.Timber;
 
@@ -56,6 +58,7 @@ public class MainActivity extends DailyDozenActivity implements ProgressListener
     private boolean alreadyHandledRestoreIntent;
 
     private boolean inDailyDozenMode = true;
+    private File backupFile;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -273,7 +276,8 @@ public class MainActivity extends DailyDozenActivity implements ProgressListener
     private void backup() {
         if (!DDServings.isEmpty()) {
             if (PermissionController.canWriteExternalStorage(this)) {
-                new TaskRunner().executeAsync(new BackupTask(this, getBackupFile()));
+                backupFile = createBackupFile();
+                new TaskRunner().executeAsync(new BackupTask(this, backupFile));
             } else {
                 PermissionController.askForWriteExternalStorage(this);
             }
@@ -315,7 +319,16 @@ public class MainActivity extends DailyDozenActivity implements ProgressListener
     }
 
     public File getBackupFile() {
-        return new File(getFilesDir(), "dailydozen_backup.json");
+        if (backupFile == null) {
+            backupFile = createBackupFile();
+        }
+        return backupFile;
+    }
+
+    private File createBackupFile() {
+        final String timestamp = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US)
+                .format(new Date());
+        return new File(getFilesDir(), "dailydozen_backup_" + timestamp + ".json");
     }
 
     private void shareBackupFile() {


### PR DESCRIPTION
## Summary
- generate a unique backup filename with timestamp (`dailydozen_backup_yyyyMMdd_HHmmss.json`)
- keep the exact backup file reference so the file created by `BackupTask` is the same one shared afterwards
- broaden restore intent `pathPattern` so both existing and timestamped backup filenames are matched

Fixes #220.

## Notes
- I attempted local validation with Gradle, but this environment is missing a Java runtime (`Unable to locate a Java Runtime`).
